### PR TITLE
NodeJS versions in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # the Node.js versions to build on
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Click the link below to create a new GitHub Repository using this template, or c
 
 ## Setup Development Environment
 
-To develop Homebridge plugins you must have Node.js 12 or later installed, and a modern code editor such as [VS Code](https://code.visualstudio.com/). This plugin template uses [TypeScript](https://www.typescriptlang.org/) to make development easier and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. If you are using VS Code install these extensions:
+To develop Homebridge plugins you must have Node.js 14 or later installed, and a modern code editor such as [VS Code](https://code.visualstudio.com/). This plugin template uses [TypeScript](https://www.typescriptlang.org/) to make development easier and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. If you are using VS Code install these extensions:
 
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 


### PR DESCRIPTION
## :recycle: Current situation

For verification of homebridge plugin one must support the node LTS versions 14.x, 16.x and 18.x (see [requirements](https://github.com/homebridge/verified#requirements)). The GitHub actions template contains versions 12.x, 13.x, 14.x, 15.x, 16.x but not 18.x. 

## :bulb: Proposed solution

Version 18.x should be added to the actions as well. 
Maybe 12.x, 13.x and 15.x could be removed as they are not mandatory?

## :gear: Release Notes

- removed workflows for Node.js versions 12.x, 13.x and 15.x
- added workflow for Node.js version 18.x

## :heavy_plus_sign: Additional Information

See existing [issue](https://github.com/homebridge/homebridge-plugin-template/issues/49).

### Testing

### Reviewer Nudging
